### PR TITLE
Re-add better checking for useless packets

### DIFF
--- a/pufferfish-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
+++ b/pufferfish-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
@@ -1,0 +1,22 @@
+--- a/net/minecraft/server/level/ServerEntity.java
++++ b/net/minecraft/server/level/ServerEntity.java
+@@ -189,7 +_,10 @@
+                     packet = ClientboundEntityPositionSyncPacket.of(this.entity);
+                     flag3 = true;
+                     flag4 = true;
+-                } else if ((!flag2 || !flag) && !(this.entity instanceof AbstractArrow)) {
++                // Pufferfish start - Better checking for useless move packets
++                } else if (flag2 || flag || this.entity instanceof AbstractArrow) {
++                 if ((!flag2 || !flag) && !(this.entity instanceof AbstractArrow)) {
++                    // Pufferfish end
+                     if (flag2) {
+                         packet = new ClientboundMoveEntityPacket.Pos(this.entity.getId(), (short)l, (short)l1, (short)l2, this.entity.onGround());
+                         flag3 = true;
+@@ -202,6 +_,7 @@
+                     flag3 = true;
+                     flag4 = true;
+                 }
++            } // Pufferfish - Better checking for useless move packets 
+ 
+                 if (this.entity.hasImpulse || this.trackDelta || this.entity instanceof LivingEntity && ((LivingEntity)this.entity).isFallFlying()) {
+                     Vec3 deltaMovement = this.entity.getDeltaMovement();


### PR DESCRIPTION
This pr adds back the "Better checking for useless move packets" patch to the fork with changes to fix the head rotation bug that caused it to be reverted in the first place, see [#111](https://github.com/pufferfish-gg/pufferfish/issues/111), [this commit](https://github.com/Toffikk/Pufferfish/commit/a9f41fca7ca3dc401b9f30cf37e2dfcc4b136342) and also [the discussion on pufferfish's discord server](https://discord.com/channels/895192260210208818/895197734703861780/1345557621666615381)
tl;dr - when pufferfish was getting updated to 1.21 the flags changed ( flag3 -> flag ) but kevin had overlooked that change by accident causing the infamous head rotation bug.

I can say this version of the patch works as i've personally tested it and also [my fork](https://github.com/Toffikk/Pufferfish) which contains that fix is used by many people and none have yet opened any issue regarding it still causing that bug whatsoever